### PR TITLE
Modify publisher to make it send both PoW and classification jobs with a percentage control

### DIFF
--- a/nostr-client-plus/README.md
+++ b/nostr-client-plus/README.md
@@ -68,11 +68,12 @@ cargo run --release --package nostr-client-plus --bin aggregator -- nostr-client
 ### Publishers
 
 Publisher needs a few environment variables:
-- `MONGO_URL` is mandatory.
+- `MONGO_URL` is mandatory (not used by pow jobs).
 - `RELAY_URL` is optional and it defaults to `ws://127.0.0.1:3031`.
 - `PUBLISHER_PRIVATE_KEY` is mandatory.
 - `PROMETHEUS_URL` is mandatory.
 - `JOBS_THRESHOLD` is optional and defaults to 5000.
+- `CLASSIFICATION_PERCENT` is optional and defaults to 100 (range is 0-100).
 
 The publisher(_pow) is basically a one-shot program, that will publish immediately N jobs to the relay.  
 When jobs are completed successfully, running it again won't pick up the same jobs, so it can be run in a cron-job.  

--- a/nostr-client-plus/src/bin/aggregator.rs
+++ b/nostr-client-plus/src/bin/aggregator.rs
@@ -116,7 +116,8 @@ async fn run() -> Result<()> {
     let connection = DbClient::with_uri_str(db_url.clone())
         .await
         .expect("Cannot connect to db");
-    let db = connection.database("mine");
+    // TODO(wangjun.hong): Store results in "mine" maybe, we need to keep this same as whatever database we use in publisher
+    let db = connection.database("test-preprocessor");
     let collection: Collection<FinishedJobs> = db.collection("finished_jobs");
     let classifier_result_collection: Collection<ClassifierResult> = db.collection("classifier_results");
 

--- a/nostr-client-plus/src/bin/publisher.rs
+++ b/nostr-client-plus/src/bin/publisher.rs
@@ -1,19 +1,18 @@
 use anyhow::Result;
-use mongodb::bson::{from_document, Document};
+use mongodb::bson::from_document;
 use mongodb::{Client as DbClient, Collection};
 use nostr_client_plus::client::Client;
+use nostr_client_plus::crypto::CryptoHash;
 use nostr_client_plus::db::{left_anti_join, RawDataEntry};
 use nostr_client_plus::event::UnsignedEvent;
 use nostr_client_plus::job_protocol::{JobType, Kind, NewJobPayload, PayloadHeader};
 use nostr_crypto::eoa_signer::EoaSigner;
 use nostr_crypto::sender_signer::SenderSigner;
 use nostr_plus_common::relay_message::RelayMessage;
+use rand::random;
 use std::convert::TryInto;
 use std::time::Duration;
-use rand::random;
 use tokio::time::{interval, Instant};
-use nostr_client_plus::crypto::CryptoHash;
-use nostr_plus_common::sender::Sender;
 
 mod utils;
 use crate::utils::get_queued_jobs;
@@ -39,19 +38,26 @@ async fn run() -> Result<()> {
     let metrics_server = std::env::var("PROMETHEUS_URL").expect("Missing PROMETHEUS_URL");
     let low_val_jobs = std::env::var("JOBS_THRESHOLD").unwrap_or(LOW_VAL_JOBS.to_string());
     let low_val_jobs: usize = low_val_jobs.parse()?;
-    // We use CLASSIFICATION_PERCENT to control % of classification jobs, we should have this value between 0 ~ 1
-    // TODO(wangjun.hong): Add a check to make sure it's a number range 0 - 1
-    let classification_job_percentage = match std::env::var("CLASSIFICATION_PERCENT").unwrap_or("0".to_string()).parse::<f64>() {
+    // Percentage (0-100) of Classifications jobs. Remainder is PoW jobs.
+    let classification_job_percentage = match std::env::var("CLASSIFICATION_PERCENT")
+        .unwrap_or("100".to_string())
+        .parse::<u8>()
+    {
         Ok(val) => {
-            val
+            // check range
+            match val {
+                0..=100 => val,
+                _ => panic!("CLASSIFICATION_PERCENT must be in range [0, 100]"),
+            }
         }
-
         Err(err) => {
-            tracing::error!("Failed to parse CLASSIFICATION_PERCENT to f64, err: {}", err);
-            0.0f64
+            panic!("Failed to parse CLASSIFICATION_PERCENT to u8: {err}");
         }
     };
-    println!("{}% jobs of all jobs published should be classification job", classification_job_percentage * 100f64);
+    println!(
+        "{}% of all jobs published should be classification job",
+        classification_job_percentage
+    );
 
     // Command line parsing
     let args: Vec<String> = std::env::args().collect();
@@ -118,31 +124,84 @@ async fn run() -> Result<()> {
         }
     });
 
+    let timestamp_now = chrono::Utc::now().timestamp() as u64;
+
     // Let's figure out number of classifications and pow to send out
-    let classification_count = (limit_publish as f64 * classification_job_percentage) as i64;
-    println!("Plan to publish {} classification jobs", classification_count);
+    let classification_count = (limit_publish * classification_job_percentage as i64) / 100_i64;
+    println!(
+        "Plan to publish {} classification jobs",
+        classification_count
+    );
 
-    // Now let's fetch all classification entries needed
-    // Note there is a side effect where the entries here can have less entries than expected in case
-    // of all entries are fetched
-    let mut entries: Vec<Document> = Vec::new();
-    // Only fetch classification jobs when the number of jobs needed is larger than 0
-    if classification_count > 0 {
-        entries = left_anti_join(&collection, "finished_jobs", classification_count).await?;
-    }
-    println!("Actually fetched {} classfications to publish", entries.len());
+    // Now let's fetch all classification entries needed.
+    // ToDo: probably if we have fewer classification jobs and fill the rest with PoW is not
+    //  what we want. Review it later.
+    let entries = left_anti_join(&collection, "finished_jobs", limit_publish).await?;
+    println!(
+        "Actually fetched {} classifications to publish: PoW will fill the rest",
+        entries.len()
+    );
+    let pow_entries = limit_publish - entries.len() as i64;
 
-    // Next, send out events
+    /*
+     * Publish classification jobs
+     */
+    let classification_type = JobType::Classification.job_type();
+    let classification_type_str = JobType::Classification.as_ref();
     let mut jobs_sent = 0;
-    for i in 0..limit_publish {
-        // Since all classifications to send out is inside entries
-        // if i is larger than len of that, it must be PoW job
-        let mut entry: Option<RawDataEntry> = None;
-        if i < entries.len() as i64 {
-            // Save to unwrap, item at i should always exists since it's less than the vec length
-            entry = from_document(entries.get(i as usize).unwrap().clone())?;
+    for entry in entries {
+        let entry: RawDataEntry = from_document(entry)?;
+        let header = PayloadHeader {
+            job_type: classification_type,
+            raw_data_id: entry._id,
+            time: timestamp_now,
+        };
+        let payload = NewJobPayload {
+            header,
+            kv_key: entry.r2_key,
+            config: None,
+            validator: "default".to_string(),
+            classifier: "default".to_string(),
+        };
+        let event = UnsignedEvent::new(
+            client.sender(),
+            timestamp_now,
+            Kind::NEW_JOB,
+            vec![vec!["t".to_string(), classification_type_str.to_string()]],
+            serde_json::to_string(&payload).expect("Payload serialization failed"),
+        );
+        if client.publish(event).await.is_err() {
+            eprintln!("Cannot publish job");
+        } else {
+            jobs_sent += 1;
         }
-        let event = construct_event(entry, client.sender());
+    }
+
+    /*
+     * Publish PoW jobs
+     */
+    let pow_type = JobType::PoW.job_type();
+    let pow_type_str = JobType::PoW.as_ref();
+    for _ in 0..pow_entries {
+        let header = PayloadHeader {
+            job_type: pow_type,
+            raw_data_id: CryptoHash::new(random()),
+            time: timestamp_now,
+        };
+        let payload = NewJobPayload {
+            header,
+            kv_key: "pow".to_string(),
+            config: None,
+            validator: "default".to_string(),
+            classifier: "default".to_string(),
+        };
+        let event = UnsignedEvent::new(
+            client.sender(),
+            timestamp_now,
+            Kind::NEW_JOB,
+            vec![vec!["t".to_string(), pow_type_str.to_string()]],
+            serde_json::to_string(&payload).expect("Payload serialization failed"),
+        );
         if client.publish(event).await.is_err() {
             eprintln!("Cannot publish job");
         } else {
@@ -153,43 +212,4 @@ async fn run() -> Result<()> {
     listener_handle.await?;
     println!("Done: {} jobs sent", jobs_sent);
     Ok(())
-}
-
-// Return a new event based on entry, when entry is None it's a
-// PoW event, otherwise it's Classification event
-fn construct_event(entry: Option<RawDataEntry>, sender: Sender) -> UnsignedEvent {
-    let timestamp_now = chrono::Utc::now().timestamp() as u64;
-    let mut job_type = JobType::PoW.job_type();
-    let mut job_type_str = JobType::PoW.as_ref();
-    let mut kv_key = "pow".to_string();
-    let mut raw_data_id = CryptoHash::new(random());
-    // In case entry is not None, it's Classification job, let's
-    // set all related fields with classification entry
-    if !entry.is_none() {
-        let entry = entry.unwrap();
-        job_type = JobType::Classification.job_type();
-        job_type_str = JobType::Classification.as_ref();
-        kv_key = entry.r2_key;
-        raw_data_id = entry._id;
-    }
-    println!("Constructing entry of id: {:?}", raw_data_id);
-    let header = PayloadHeader {
-        job_type,
-        raw_data_id,
-        time: timestamp_now,
-    };
-    let payload = NewJobPayload {
-        header,
-        kv_key,
-        config: None,
-        validator: "default".to_string(),
-        classifier: "default".to_string(),
-    };
-    UnsignedEvent::new(
-        sender,
-        timestamp_now,
-        Kind::NEW_JOB,
-        vec![vec!["t".to_string(), job_type_str.to_string()]],
-        serde_json::to_string(&payload).expect("Payload serialization failed"),
-    )
 }

--- a/nostr-client-plus/src/bin/publisher.rs
+++ b/nostr-client-plus/src/bin/publisher.rs
@@ -38,7 +38,7 @@ async fn run() -> Result<()> {
     let metrics_server = std::env::var("PROMETHEUS_URL").expect("Missing PROMETHEUS_URL");
     let low_val_jobs = std::env::var("JOBS_THRESHOLD").unwrap_or(LOW_VAL_JOBS.to_string());
     let low_val_jobs: usize = low_val_jobs.parse()?;
-    // Percentage (0-100) of Classifications jobs. Remainder is PoW jobs.
+    // Percentage (0-100) of classification jobs. Remainder is PoW jobs.
     let classification_job_percentage = match std::env::var("CLASSIFICATION_PERCENT")
         .unwrap_or("100".to_string())
         .parse::<u8>()
@@ -163,12 +163,19 @@ async fn run() -> Result<()> {
             validator: "default".to_string(),
             classifier: "default".to_string(),
         };
+        let content = match serde_json::to_string(&payload) {
+            Ok(val) => val,
+            Err(err) => {
+                eprintln!("Failed to serialize payload: {}", err);
+                continue;
+            }
+        };
         let event = UnsignedEvent::new(
             client.sender(),
             timestamp_now,
             Kind::NEW_JOB,
             vec![vec!["t".to_string(), classification_type_str.to_string()]],
-            serde_json::to_string(&payload).expect("Payload serialization failed"),
+            content,
         );
         if client.publish(event).await.is_err() {
             eprintln!("Cannot publish job");
@@ -195,12 +202,19 @@ async fn run() -> Result<()> {
             validator: "default".to_string(),
             classifier: "default".to_string(),
         };
+        let content = match serde_json::to_string(&payload) {
+            Ok(val) => val,
+            Err(err) => {
+                eprintln!("Failed to serialize payload: {}", err);
+                continue;
+            }
+        };
         let event = UnsignedEvent::new(
             client.sender(),
             timestamp_now,
             Kind::NEW_JOB,
             vec![vec!["t".to_string(), pow_type_str.to_string()]],
-            serde_json::to_string(&payload).expect("Payload serialization failed"),
+            content,
         );
         if client.publish(event).await.is_err() {
             eprintln!("Cannot publish job");


### PR DESCRIPTION
# Summary
With this change, publisher now will send both PoW and classification jobs based on env: `CLASSIFICATION_PERCENT` to control the percentage of classification jobs

# Test
- [x] Run locally with `CLASSIFICATION_PERCENT = 0` and `CLASSIFICATION_PERCENT = 1` and make sure we see 1 PoW job and 1 Classification job